### PR TITLE
Fix skip executor

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - '*'
-
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - '*'
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -321,13 +321,15 @@ func (cc *jobcontroller) syncJob(jobInfo *apis.JobInfo, updateStatus state.Updat
 		go func(pod *v1.Pod) {
 			defer waitCreationGroup.Done()
 
-			exec := strconv.Itoa(int(count))
+			countStr := strconv.Itoa(int(count))
 
 			if counterLabelFound {
-				pod.Labels[counterLabel] = exec
+				_, exists := pod.Labels[counterLabel]
+				if !exists {
+					pod.Labels[counterLabel] = countStr
+					count++
+				}
 			}
-
-			count++
 
 			newPod, err := cc.kubeClient.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
 			if err != nil && !apierrors.IsAlreadyExists(err) {

--- a/pkg/controllers/job/job_controller_actions_test.go
+++ b/pkg/controllers/job/job_controller_actions_test.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
+	"strconv"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -306,12 +308,16 @@ func TestSyncJobFunc(t *testing.T) {
 				t.Errorf("Expected Total number of pods to be same as podlist count: Expected: %d, Got: %d in case: %d", testcase.TotalNumPods, len(podList.Items), i)
 			}
 
-			var podIds []string
+			var podIds []int
 			for _, pod := range podList.Items {
-				podIds = append(podIds, pod.Labels["VK_POD_ID"])
+				id, _ := strconv.Atoi(pod.Labels["VK_POD_ID"])
+				podIds = append(podIds, id)
 			}
 
-			if !reflect.DeepEqual(podIds, []string{"0", "1", "2", "3", "4", "5"}) {
+			// pods can appear out of order, so we need to sort it before comparing with expected
+			sort.Ints(podIds)
+
+			if !reflect.DeepEqual(podIds, []int{0, 1, 2, 3, 4, 5}) {
 				t.Error("Error when incrementing the counter of the jobs")
 			}
 		})


### PR DESCRIPTION
1. Fix test by comparing sorted array of executor ids.
2. Fix data race error by updating & reading atomic counter. 
3. Only add executor id label once, if it doesn't exist.