### PR TITLE
Dynamic queue config

### DIFF
--- a/cmd/webhook-manager/app/options/options.go
+++ b/cmd/webhook-manager/app/options/options.go
@@ -42,6 +42,7 @@ type Config struct {
 	WebhookNamespace  string
 	SchedulerName     string
 	WebhookURL        string
+	QueueConfigFile   string
 }
 
 // NewConfig create new config.
@@ -69,6 +70,7 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.WebhookURL, "webhook-url", "", "The url of this webhook")
 
 	fs.StringVar(&c.SchedulerName, "scheduler-name", defaultSchedulerName, "Volcano will handle pods whose .spec.SchedulerName is same as scheduler-name")
+	fs.StringVar(&c.QueueConfigFile, "queue-config-file", "", "File containing weights for the dynamic queue hierarchy nodes.")
 }
 
 // CheckPortOrDie check valid port range.

--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -46,7 +46,7 @@ type HierarchyWeights struct {
 // readQueueConfig Read Dynamic Queue Configuration from a file.
 func readQueueConfig(filePath string) map[string]int32 {
 	hierarchyWeights := make(map[string]int32)
-
+	klog.V(3).Infof("Trying to read Hierarchy weights from <%s>", filePath)
 	contentBytes, err := ioutil.ReadFile(filePath)
 
 	if err != nil {
@@ -65,6 +65,7 @@ func readQueueConfig(filePath string) map[string]int32 {
 
 	for nodeName, nodeWeight := range weightsConf.Weights {
 		hierarchyWeights[nodeName] = int32(nodeWeight)
+		klog.V(3).Infof("Using hierarchy weight <%d> for <%s>", nodeName, nodeWeight)
 	}
 	return hierarchyWeights
 }

--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -95,6 +95,13 @@ func Run(config *options.Config) error {
 	kubeClient := getKubeClient(restConfig)
 	queueConfig := readQueueConfig(config.QueueConfigFile)
 
+	// Fail the admission container if no hierarchy weights are found
+	// This is not compatible with the dap use-case
+	if len(queueConfig) == 0 {
+		return fmt.Errorf("no queue hierarchy weights found in <%s>. Plase check admission configuration",
+			config.QueueConfigFile)
+	}
+
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: config.SchedulerName})

--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -40,7 +40,7 @@ import (
 
 // HierarchyWeights user configured weights for the queue hierarchy
 type HierarchyWeights struct {
-	Weights map[string]int `yaml:"hierarchy-weights"`
+	Weights map[string]int
 }
 
 // readQueueConfig Read Dynamic Queue Configuration from a file.

--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -48,7 +48,6 @@ func readQueueConfig(filePath string) map[string]int32 {
 	hierarchyWeights := make(map[string]int32)
 	klog.V(3).Infof("Trying to read Hierarchy weights from <%s>", filePath)
 	contentBytes, err := ioutil.ReadFile(filePath)
-	klog.V(3).Infof("File content is: <%s>", string(contentBytes))
 
 	if err != nil {
 		klog.Errorf("Queue config file <%s> does not exist or cannot be read: <%s>", filePath, err.Error())
@@ -58,7 +57,6 @@ func readQueueConfig(filePath string) map[string]int32 {
 	// Try to unmarshall the YAML
 	weightsConf := &HierarchyWeights{}
 	err = yaml.Unmarshal(contentBytes, weightsConf)
-	klog.V(3).Infof("After unmarshall: size of config is: <%d>", len(weightsConf.Weights))
 
 	if err != nil {
 		klog.Errorf("Parse error in Queue config file <%s>: <%s>", filePath, err.Error())

--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -50,7 +50,7 @@ func readQueueConfig(filePath string) map[string]int32 {
 	contentBytes, err := ioutil.ReadFile(filePath)
 
 	if err != nil {
-		klog.Warningf("Queue config file <%s> does not exist or cannot be read: <%s>", filePath, err.Error())
+		klog.Errorf("Queue config file <%s> does not exist or cannot be read: <%s>", filePath, err.Error())
 		return hierarchyWeights
 	}
 
@@ -59,7 +59,7 @@ func readQueueConfig(filePath string) map[string]int32 {
 	err = yaml.Unmarshal(contentBytes, weightsConf)
 
 	if err != nil {
-		klog.Warningf("Parse error in Queue config file <%s>: <%s>", filePath, err.Error())
+		klog.Errorf("Parse error in Queue config file <%s>: <%s>", filePath, err.Error())
 		return hierarchyWeights
 	}
 
@@ -94,6 +94,10 @@ func Run(config *options.Config) error {
 	vClient := getVolcanoClient(restConfig)
 	kubeClient := getKubeClient(restConfig)
 	queueConfig := readQueueConfig(config.QueueConfigFile)
+
+	if len(queueConfig) == 0 {
+		return fmt.Errorf("no hierarchy weights found")
+	}
 
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})

--- a/pkg/webhooks/admission/jobs/validate/admit_job.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job.go
@@ -192,9 +192,14 @@ func validateJobCreate(job *v1alpha1.Job, reviewResponse *v1beta1.AdmissionRespo
 	}
 
 	if dynamicQueue, ok := job.Annotations["volcano.sh/dynamic-queue"]; ok {
+		// dynamic queue name must start with "root", otherwise DRF does not work properly.
 		queueHierarchy := strings.Split(dynamicQueue, "/")
-		if err := createDynamicQueue(queueHierarchy); err != nil {
-			msg += err.Error()
+		if queueHierarchy[0] == "root" {
+			if err := createDynamicQueue(queueHierarchy); err != nil {
+				msg += err.Error()
+			}
+		} else {
+			msg += fmt.Sprintf("Dynamic Queue name <%s> does not start with root", dynamicQueue)
 		}
 	}
 

--- a/pkg/webhooks/admission/jobs/validate/admit_job.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job.go
@@ -192,8 +192,8 @@ func validateJobCreate(job *v1alpha1.Job, reviewResponse *v1beta1.AdmissionRespo
 	}
 
 	if dynamicQueue, ok := job.Annotations["volcano.sh/dynamic-queue"]; ok {
-		var queues = strings.Split(dynamicQueue, "/")
-		if err := createDynamicQueue(queues, []int32{}, []string{}); err != nil {
+		queueHierarchy := strings.Split(dynamicQueue, "/")
+		if err := createDynamicQueue(queueHierarchy); err != nil {
 			msg += err.Error()
 		}
 	}
@@ -213,48 +213,48 @@ func validateJobCreate(job *v1alpha1.Job, reviewResponse *v1beta1.AdmissionRespo
 	return msg
 }
 
-func createDynamicQueue(queues []string, parentWeights []int32, parentQueues []string) error {
+// createDynamicQueue Dynamically create the queue hierarchy node by node, checking if each node exists and creating
+// if it does not. Construct the hierarchy weight by concatenating the hierarchy weights defined in configuration.
+func createDynamicQueue(queueHierarchy []string) error {
 
-	var newWeight []int32
-	var newQueues []string
-
-	queueName := queues[0]
-	remainderQueue := queues[1:]
-
-	newQueues = append(parentQueues, queueName)
-
-	if queueName == mutate.DefaultQueue {
-		newWeight = append(parentWeights, 1)
-		return createDynamicQueue(remainderQueue, newWeight, newQueues)
-	}
-
-	parentQueue, err := config.VolcanoClient.SchedulingV1beta1().Queues().Get(context.TODO(), queueName, metav1.GetOptions{})
-
-	if errors.IsNotFound(err) {
-		newWeight = append(parentWeights, 1)
-
-		hierarchyWeights := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(newWeight)), "/"), "[]")
-		hierarchy := strings.Trim(strings.Join(newQueues, "/"), "[]")
-
-		klog.V(3).Infof("admit dynamic queue <`%s`>", queueName)
-
-		if _, err = createQueue(queueName, hierarchy, hierarchyWeights); err != nil {
-			return fmt.Errorf("unable to admit queue <`%s`>: %v", queueName, err)
+	for _, nodeName := range queueHierarchy {
+		if nodeName == mutate.DefaultQueue {
+			return errors.NewBadRequest("Cannot use default queue as part of the hierarchy.")
 		}
-	} else if err != nil {
-		return fmt.Errorf("unable to retrieve queue<`%s`>: `%v`", queueName, err)
-	} else if parentQueue.Status.State == schedulingv1beta1.QueueStateOpen {
-		klog.V(3).Infof("accept queue <`%s`> new jobs", queueName)
-		newWeight = append(parentWeights, parentQueue.Spec.Weight)
+	}
+
+	n := len(queueHierarchy)
+	queueName := queueHierarchy[n-1]
+
+	// Check if the queue already exists
+	_, getError := config.VolcanoClient.SchedulingV1beta1().Queues().Get(
+		context.TODO(),
+		queueName,
+		metav1.GetOptions{})
+
+	if errors.IsNotFound(getError) {
+		hierarchy := strings.Join(queueHierarchy, "/")
+
+		// Construct the hierarchy weight by checking if each node in the path has a weight specified
+		// in the config. If not found, use 1 as default
+		var hierarchyWeights []string
+
+		for _, name := range queueHierarchy {
+			weight, exists := config.QueueConfig[name]
+			if exists {
+				hierarchyWeights = append(hierarchyWeights, fmt.Sprintf("%d", weight))
+			} else {
+				hierarchyWeights = append(hierarchyWeights, "1")
+			}
+		}
+		_, err := createQueue(queueName, hierarchy, strings.Join(hierarchyWeights, "/"))
+		if err != nil {
+			return err
+		}
 	} else {
-		return fmt.Errorf("unable to use queue <`%s`> with status<`%s`>", parentQueue.Name, parentQueue.Status.State)
+		klog.V(3).Infof("Queue <%s> already exists.", queueName)
 	}
-
-	if len(remainderQueue) == 0 {
-		return nil
-	}
-
-	return createDynamicQueue(remainderQueue, newWeight, newQueues)
+	return nil
 }
 
 func createQueue(queueName string, hierarchy string, hierarchyWeights string) (*schedulingv1beta1.Queue, error) {
@@ -275,12 +275,12 @@ func createQueue(queueName string, hierarchy string, hierarchyWeights string) (*
 	}
 
 	if _, err := config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), &queue, metav1.CreateOptions{}); err != nil {
-		fmt.Sprintf("unable to create the dynamic queue <`%s`>: %v", queueName, err)
+		klog.Errorf("unable to create the dynamic queue <`%s`>: %v", queueName, err)
 		return nil, err
 	}
 
 	if err := wait.PollImmediate(time.Second/2, time.Second*5, isQueueRunning(queueName)); err != nil {
-		fmt.Sprintf("unable to use the dynamic queue <`%s`>: %v", queueName, err)
+		klog.Errorf("unable to use the dynamic queue <`%s`>: %v", queueName, err)
 		return nil, err
 	}
 

--- a/pkg/webhooks/admission/jobs/validate/admit_job.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job.go
@@ -274,6 +274,8 @@ func createQueue(queueName string, hierarchy string, hierarchyWeights string) (*
 		},
 	}
 
+	klog.V(3).Infof("Trying to create queue <%s> with hierarchy <%s>, weights <%s>",
+		queueName, hierarchy, hierarchyWeights)
 	if _, err := config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), &queue, metav1.CreateOptions{}); err != nil {
 		klog.Errorf("unable to create the dynamic queue <`%s`>: %v", queueName, err)
 		return nil, err

--- a/pkg/webhooks/admission/jobs/validate/admit_job_test.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job_test.go
@@ -1072,7 +1072,43 @@ func TestValidateJobCreate(t *testing.T) {
 			ExpectErr:      false,
 		},
 		{
-			Name: "job with recursively dynamic created queue",
+			Name: "Try to create job where dynamic queue hierarchy does not start with root",
+			Job: v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "valid-job",
+					Namespace:   namespace,
+					Annotations: map[string]string{"volcano.sh/dynamic-queue": "test/user1"},
+				},
+				Spec: v1alpha1.JobSpec{
+					MinAvailable: 1,
+					Queue:        "test",
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "task-1",
+							Replicas: 1,
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Labels: map[string]string{"name": "test"},
+								},
+								Spec: v1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name:  "fake-name",
+											Image: "busybox:1.24",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			reviewResponse: v1beta1.AdmissionResponse{Allowed: false},
+			ret:            "",
+			ExpectErr:      true,
+		},
+		{
+			Name: "job with nested dynamic created queue",
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "valid-job",

--- a/pkg/webhooks/admission/jobs/validate/admit_job_test.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job_test.go
@@ -1041,7 +1041,7 @@ func TestValidateJobCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "valid-job",
 					Namespace:   namespace,
-					Annotations: map[string]string{"volcano.sh/dynamic-queue": "default/test"},
+					Annotations: map[string]string{"volcano.sh/dynamic-queue": "root/test"},
 				},
 				Spec: v1alpha1.JobSpec{
 					MinAvailable: 1,
@@ -1077,47 +1077,11 @@ func TestValidateJobCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "valid-job",
 					Namespace:   namespace,
-					Annotations: map[string]string{"volcano.sh/dynamic-queue": "default/one/two"},
+					Annotations: map[string]string{"volcano.sh/dynamic-queue": "root/one/two"},
 				},
 				Spec: v1alpha1.JobSpec{
 					MinAvailable: 1,
 					Queue:        "two",
-					Tasks: []v1alpha1.TaskSpec{
-						{
-							Name:     "task-1",
-							Replicas: 1,
-							Template: v1.PodTemplateSpec{
-								ObjectMeta: metav1.ObjectMeta{
-									Labels: map[string]string{"name": "test"},
-								},
-								Spec: v1.PodSpec{
-									Containers: []v1.Container{
-										{
-											Name:  "fake-name",
-											Image: "busybox:1.24",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			reviewResponse: v1beta1.AdmissionResponse{Allowed: true},
-			ret:            "",
-			ExpectErr:      false,
-		},
-		{
-			Name: "job with unsupported queue",
-			Job: v1alpha1.Job{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "valid-job",
-					Namespace:   namespace,
-					Annotations: map[string]string{"volcano.sh/dynamic-queue": "notexist/one"},
-				},
-				Spec: v1alpha1.JobSpec{
-					MinAvailable: 1,
-					Queue:        "notexist",
 					Tasks: []v1alpha1.TaskSpec{
 						{
 							Name:     "task-1",

--- a/pkg/webhooks/router/interface.go
+++ b/pkg/webhooks/router/interface.go
@@ -32,6 +32,7 @@ type AdmissionServiceConfig struct {
 	KubeClient    kubernetes.Interface
 	VolcanoClient versioned.Interface
 	Recorder      record.EventRecorder
+	QueueConfig   map[string]int32
 }
 
 type AdmissionService struct {


### PR DESCRIPTION
Adds a configuration file option for the "admissions" application. This file should contain the weights for specific nodes in the queue hiearchy, e.g. 

weights: { "root": 100, "batch": 30, "interactive": 70, "dap-process": 24}

It is populated during installation from a configmap attached as a volume mount to the "admission" container, similar to other configuration files. 

If this file is specified, the admission controller will read and save the weights mapping in the AdmissionConfig. During dynamic queue creation, the handler for the job validation function will construct the hierarchy weight from the hierarchy string using this mapping. If a node is not found in the mapping, the corresponding weight defaults to 1. For example, the hierarchy weight for "root/batch/test1" is "100/30/1". 

Also corrects the queue creation step: only the leaf node in the hierarchy is used to create as a queues.scheduling.volcano.sh custom resource.
